### PR TITLE
Value converters

### DIFF
--- a/sample/src/main.js
+++ b/sample/src/main.js
@@ -12,6 +12,7 @@ export function configure(aurelia) {
   aurelia.use.globalResources('shared/markdown');
   aurelia.use.globalResources('shared/logger');
   aurelia.use.globalResources('shared/au-code');
+  aurelia.use.globalResources('samples/grid/capitalize');
 
   aurelia.start()
   .then(au => {

--- a/sample/src/samples/grid/advanced.html
+++ b/sample/src/samples/grid/advanced.html
@@ -1,0 +1,7 @@
+<template>
+  <k-grid k-data-source.bind="datasource">
+    <k-col title="Contact Name" field="ContactName">
+      ${ContactName | capitalize}
+    </k-col>
+  </k-grid>
+</template>

--- a/sample/src/samples/grid/advanced.js
+++ b/sample/src/samples/grid/advanced.js
@@ -1,0 +1,11 @@
+export class Advanced {
+  datasource = {
+    data: [{
+      ContactName: "jeroen"
+    }, {
+      ContactName: "charles"
+    }, {
+      ContactName: "nikolaj"
+    }]
+  }
+}

--- a/sample/src/samples/grid/advanced.js
+++ b/sample/src/samples/grid/advanced.js
@@ -1,11 +1,11 @@
 export class Advanced {
   datasource = {
     data: [{
-      ContactName: "jeroen"
+      ContactName: 'jeroen'
     }, {
-      ContactName: "charles"
+      ContactName: 'charles'
     }, {
-      ContactName: "nikolaj"
+      ContactName: 'nikolaj'
     }]
   }
 }

--- a/sample/src/samples/grid/basic-use.html
+++ b/sample/src/samples/grid/basic-use.html
@@ -2,7 +2,7 @@
     <require from="./basic-use.css"></require>
 
     <k-grid k-data-source.bind="datasource" k-pageable.bind="pageable" k-sortable.bind="true">
-      <k-col title="Contact Name" field="ContactName">
+      <k-col title="Contact Name" field="ContactName" with-kendo-templates.bind="true">
         <div class='customer-photo' style="background-image: url(http://demos.telerik.com/kendo-ui/content/web/Customers/${CustomerID}.jpg);"></div>
         <div class='customer-name'>${ContactName}</div>
       </k-col>

--- a/sample/src/samples/grid/capitalize.js
+++ b/sample/src/samples/grid/capitalize.js
@@ -1,6 +1,7 @@
 export class CapitalizeValueConverter {
   toView(text) {
-    if(text)
+    if (text) {
       return text.charAt(0).toUpperCase() + text.slice(1);
+    }
   }
 }

--- a/sample/src/samples/grid/capitalize.js
+++ b/sample/src/samples/grid/capitalize.js
@@ -1,0 +1,6 @@
+export class CapitalizeValueConverter {
+  toView(text) {
+    if(text)
+      return text.charAt(0).toUpperCase() + text.slice(1);
+  }
+}

--- a/sample/src/samples/grid/registry.json
+++ b/sample/src/samples/grid/registry.json
@@ -18,6 +18,7 @@
     "initialization-from-table": {},
     "inline-editing": {},
     "popup-editing": {},
-    "working-offline": {}
+    "working-offline": {},
+    "advanced": {}
   }
 }

--- a/src/grid/grid.js
+++ b/src/grid/grid.js
@@ -49,6 +49,15 @@ export class Grid  {
     // allow for both column definitions via HTML and via an array of columns
     if (this.columns && this.columns.length > 0) {
       options.columns = this.columns;
+
+      options.columns.forEach(c => {
+        if (c.template && !c.withKendoTemplates) {
+          let template = c.template;
+          c.template = function() {
+            return template;
+          };
+        }
+      });
     }
   }
 

--- a/src/grid/k-col.js
+++ b/src/grid/k-col.js
@@ -38,6 +38,7 @@ export class Col {
   @bindable values;
   @bindable width;
   @bindable template;
+  @bindable withKendoTemplates = false;
 
   constructor(targetInstruction) {
     this.template = targetInstruction.elementInstruction.template;

--- a/test/unit/grid/grid.spec.js
+++ b/test/unit/grid/grid.spec.js
@@ -1,0 +1,40 @@
+import {Grid as Widget} from 'src/grid/grid';
+import {initialize} from 'aurelia-pal-browser';
+import {DOM} from 'aurelia-pal';
+import {Container} from 'aurelia-dependency-injection';
+import {TemplatingEngine} from 'aurelia-templating';
+
+describe('Grid', () => {
+  let element;
+  let sut;
+  let container;
+  let templatingEngine;
+
+  beforeEach(() => {
+    initialize();
+    container = new Container();
+    element = DOM.createElement('div');
+    container.registerInstance(DOM.Element, element);
+    templatingEngine = container.get(TemplatingEngine);
+    sut = templatingEngine.createViewModelForUnitTest(Widget, null, {});
+  });
+
+  it('disables the Kendo templating system on a column basis', () => {
+    let options = {};
+
+    sut.columns = [{
+      withKendoTemplates: false,
+      template: "template1"
+    }, {
+      withKendoTemplates: true,
+      template: "template2"
+    }];
+
+
+    sut._beforeInitialize(options);
+
+    let columns = options.columns;
+    expect(columns[0].template()).toBe("template1");
+    expect(columns[1].template).toBe("template2");
+  });
+});

--- a/test/unit/grid/grid.spec.js
+++ b/test/unit/grid/grid.spec.js
@@ -24,17 +24,17 @@ describe('Grid', () => {
 
     sut.columns = [{
       withKendoTemplates: false,
-      template: "template1"
+      template: 'template1'
     }, {
       withKendoTemplates: true,
-      template: "template2"
+      template: 'template2'
     }];
 
 
     sut._beforeInitialize(options);
 
     let columns = options.columns;
-    expect(columns[0].template()).toBe("template1");
-    expect(columns[1].template).toBe("template2");
+    expect(columns[0].template()).toBe('template1');
+    expect(columns[1].template).toBe('template2');
   });
 });


### PR DESCRIPTION
@adriatic @charlespockert 

if we enable the Kendo templating system for a column template we can't use value converters.

if we disable the Kendo templating system we get 404's when you use images with interpolation expressions in the `src`. After the 404, Aurelia's enhance feature kicks in and everything renders fine after that.

I have made it so that the Kendo templating system is disabled by default, but you can enable it on column basis using the  ` with-kendo-templates`  property on the ` k-col`  custom element.