### PR TITLE
chore(all): export constants, decorators and events to d.ts on module level

### DIFF
--- a/build/tasks/build.js
+++ b/build/tasks/build.js
@@ -14,6 +14,11 @@ var vinylPaths = require('vinyl-paths');
 
 var jsName = paths.packageName + '.js';
 
+// RegExp remove tags during insert.transform in build-index gulp task
+var startTag = '//\\s*build-index-remove start';
+var endTag = '//\\s*build-index-remove end';
+var removeRegExp = new RegExp(startTag + '[^]+?' + endTag, 'g');
+
 gulp.task('build-index', function(){
   var importsToAdd = [];
 
@@ -25,7 +30,7 @@ gulp.task('build-index', function(){
     }))
     .pipe(concat(jsName))
     .pipe(insert.transform(function(contents) {
-      return tools.createImportBlock(importsToAdd) + contents;
+      return tools.createImportBlock(importsToAdd) + contents.replace(removeRegExp, '');
     }))
     .pipe(gulp.dest(paths.output));
 });

--- a/src/index.js
+++ b/src/index.js
@@ -22,3 +22,9 @@ export function configure(aurelia, configCallback) {
     repeatStrategyLocator.addStrategy(items => items instanceof kendo.data.ObservableArray, new ArrayRepeatStrategy());
   }
 }
+
+// build-index-remove start
+export * from './common/constants';
+export * from './common/decorators';
+export * from './common/events';
+// build-index-remove end


### PR DESCRIPTION
This change exports constants, decorators and events to d.ts on module level as an attempt to fix #493.

The issue description seems similar to https://github.com/aurelia-ui-toolkits/aurelia-materialize-bridge/issues/136#issuecomment-196803909 so I copied the solution. :smile: 

Typescript users can import f.i. `delayed` like this:
```javascript
import {delayed} from 'aurelia-kendoui-bridge';
```
