### PR TITLE
fix(multiselect): do not process value changes when user input is pre…

### DIFF
--- a/src/multiselect/multiselect.js
+++ b/src/multiselect/multiselect.js
@@ -52,7 +52,10 @@ export class Multiselect {
   }
 
   propertyChanged(property, newValue, oldValue) {
-    this.widgetBase.handlePropertyChanged(this.kWidget, property, newValue, oldValue);
+    // do not process value changes when user input is present
+    if(property !== 'kValue' || this.kWidget.input.val() === '') {
+      this.widgetBase.handlePropertyChanged(this.kWidget, property, newValue, oldValue);
+    }
   }
 
   detached() {


### PR DESCRIPTION
…sent

WidgetBase calls handleValueChanged when a `dataBound` event is triggered.   This causes issues in filter scenarios in which user input causes a filter event (and in turn a `dataBound` event ).   This change skips updating `kValue` if user input is present in the input field (causing a filtered display). 

All examples verified working in component catalog.

Fixes #515 
Fixes #516