### PR TITLE
Call destroy before empty

### DIFF
--- a/src/common/widget-base.js
+++ b/src/common/widget-base.js
@@ -352,8 +352,8 @@ export class WidgetBase {
         }
       }
 
-      widget.element.show().empty();
       kendo.destroy(widget.element);
+      widget.element.show().empty();
 
       widget = null;
 


### PR DESCRIPTION
Allow kendo to destroy nested widgets before calling empty on the
element.