### PR TITLE
fix(combobox): Force sync on bind

### DIFF
--- a/src/combobox/combobox.js
+++ b/src/combobox/combobox.js
@@ -26,6 +26,9 @@ export class ComboBox {
 
   bind(ctx, overrideCtx) {
     this.widgetBase.useParentCtx(overrideCtx);
+    if (this.kWidget) {
+      this.kWidget.value(this.value);
+    }
   }
 
   attached() {


### PR DESCRIPTION
Fixes an issue with the combo box where bindings refresh after the element is attached. Previously, my element would not properly bind to the value.