### PR TITLE
Changed $ to kendo.jQuery in template handling

### DIFF
--- a/src/common/template-compiler.js
+++ b/src/common/template-compiler.js
@@ -135,7 +135,7 @@ export class TemplateCompiler {
   enhanceView($parent, element, ctx, container) {
     let view = kendo.jQuery(element).data('viewInstance');
 
-    $(element).data('$$kendoScope', ctx);
+    kendo.jQuery(element).data('$$kendoScope', ctx);
 
     // check necessary due to https://github.com/aurelia-ui-toolkits/aurelia-kendoui-bridge/issues/308
     if (element.querySelectorAll('.au-target').length === 0) {

--- a/src/common/template.js
+++ b/src/common/template.js
@@ -9,9 +9,9 @@ import {constants} from '../common/constants';
   if (html !== '') {
     // if there's a script tag in the template, take the innerHTML of the script tag
     // https://github.com/aurelia-ui-toolkits/aurelia-kendoui-bridge/issues/580
-    let script = $(element).children('script');
+    let script = kendo.jQuery(element).children('script');
     if (script.length > 0) {
-      instruction.template = $(script).html();
+      instruction.template = kendo.jQuery(script).html();
     } else {
       // no script tags? the template is the innerHTML
       instruction.template = html;


### PR DESCRIPTION
I have a project where the usual suggestions to handle "$ is undefined" errors (webpack plugin, script tag to import jQuery, etc.) either don't work or unacceptable.

After looking at the code and the docs for this project it seems that referencing $ is not acceptable and should be kendo.jQuery, which is guaranteed to be available.