### PR TITLE
Removed Lexer() from template-gatherer due to aurelia-binding 2.0.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ vendors
 build/reports
 devbuild
 temp
+package-lock.json

--- a/config.js
+++ b/config.js
@@ -15,15 +15,15 @@ System.config({
   },
 
   map: {
-    "aurelia-binding": "npm:aurelia-binding@1.2.1",
+    "aurelia-binding": "npm:aurelia-binding@2.1.1",
     "aurelia-dependency-injection": "npm:aurelia-dependency-injection@1.3.1",
-    "aurelia-logging": "npm:aurelia-logging@1.3.1",
-    "aurelia-metadata": "npm:aurelia-metadata@1.0.3",
-    "aurelia-pal": "npm:aurelia-pal@1.3.0",
+    "aurelia-logging": "npm:aurelia-logging@1.5.0",
+    "aurelia-metadata": "npm:aurelia-metadata@1.0.4",
+    "aurelia-pal": "npm:aurelia-pal@1.8.0",
     "aurelia-pal-browser": "npm:aurelia-pal-browser@1.2.1",
     "aurelia-polyfills": "npm:aurelia-polyfills@1.2.1",
     "aurelia-router": "npm:aurelia-router@1.3.0",
-    "aurelia-task-queue": "npm:aurelia-task-queue@1.2.0",
+    "aurelia-task-queue": "npm:aurelia-task-queue@1.3.1",
     "aurelia-templating": "npm:aurelia-templating@1.4.1",
     "aurelia-templating-resources": "npm:aurelia-templating-resources@1.4.0",
     "aurelia-testing": "npm:aurelia-testing@0.4.2",
@@ -59,10 +59,16 @@ System.config({
       "util": "npm:util@0.10.3"
     },
     "npm:aurelia-binding@1.2.1": {
-      "aurelia-logging": "npm:aurelia-logging@1.3.1",
-      "aurelia-metadata": "npm:aurelia-metadata@1.0.3",
-      "aurelia-pal": "npm:aurelia-pal@1.3.0",
-      "aurelia-task-queue": "npm:aurelia-task-queue@1.2.0"
+      "aurelia-logging": "npm:aurelia-logging@1.5.0",
+      "aurelia-metadata": "npm:aurelia-metadata@1.0.4",
+      "aurelia-pal": "npm:aurelia-pal@1.8.0",
+      "aurelia-task-queue": "npm:aurelia-task-queue@1.3.1"
+    },
+    "npm:aurelia-binding@2.1.1": {
+      "aurelia-logging": "npm:aurelia-logging@1.5.0",
+      "aurelia-metadata": "npm:aurelia-metadata@1.0.4",
+      "aurelia-pal": "npm:aurelia-pal@1.8.0",
+      "aurelia-task-queue": "npm:aurelia-task-queue@1.3.1"
     },
     "npm:aurelia-bootstrapper@1.0.1": {
       "aurelia-event-aggregator": "npm:aurelia-event-aggregator@1.0.1",
@@ -71,7 +77,7 @@ System.config({
       "aurelia-history-browser": "npm:aurelia-history-browser@1.0.0",
       "aurelia-loader-default": "npm:aurelia-loader-default@1.0.2",
       "aurelia-logging-console": "npm:aurelia-logging-console@1.0.0",
-      "aurelia-pal": "npm:aurelia-pal@1.3.0",
+      "aurelia-pal": "npm:aurelia-pal@1.8.0",
       "aurelia-pal-browser": "npm:aurelia-pal-browser@1.2.1",
       "aurelia-polyfills": "npm:aurelia-polyfills@1.2.1",
       "aurelia-router": "npm:aurelia-router@1.3.0",
@@ -81,47 +87,47 @@ System.config({
       "aurelia-templating-router": "npm:aurelia-templating-router@1.1.0"
     },
     "npm:aurelia-dependency-injection@1.3.1": {
-      "aurelia-metadata": "npm:aurelia-metadata@1.0.3",
-      "aurelia-pal": "npm:aurelia-pal@1.3.0"
+      "aurelia-metadata": "npm:aurelia-metadata@1.0.4",
+      "aurelia-pal": "npm:aurelia-pal@1.8.0"
     },
     "npm:aurelia-event-aggregator@1.0.1": {
-      "aurelia-logging": "npm:aurelia-logging@1.3.1"
+      "aurelia-logging": "npm:aurelia-logging@1.5.0"
     },
     "npm:aurelia-framework@1.1.2": {
       "aurelia-binding": "npm:aurelia-binding@1.2.1",
       "aurelia-dependency-injection": "npm:aurelia-dependency-injection@1.3.1",
       "aurelia-loader": "npm:aurelia-loader@1.0.0",
-      "aurelia-logging": "npm:aurelia-logging@1.3.1",
-      "aurelia-metadata": "npm:aurelia-metadata@1.0.3",
-      "aurelia-pal": "npm:aurelia-pal@1.3.0",
+      "aurelia-logging": "npm:aurelia-logging@1.5.0",
+      "aurelia-metadata": "npm:aurelia-metadata@1.0.4",
+      "aurelia-pal": "npm:aurelia-pal@1.8.0",
       "aurelia-path": "npm:aurelia-path@1.1.1",
-      "aurelia-task-queue": "npm:aurelia-task-queue@1.2.0",
+      "aurelia-task-queue": "npm:aurelia-task-queue@1.3.1",
       "aurelia-templating": "npm:aurelia-templating@1.4.1"
     },
     "npm:aurelia-history-browser@1.0.0": {
       "aurelia-history": "npm:aurelia-history@1.0.0",
-      "aurelia-pal": "npm:aurelia-pal@1.3.0"
+      "aurelia-pal": "npm:aurelia-pal@1.8.0"
     },
     "npm:aurelia-loader-default@1.0.2": {
       "aurelia-loader": "npm:aurelia-loader@1.0.0",
-      "aurelia-metadata": "npm:aurelia-metadata@1.0.3",
-      "aurelia-pal": "npm:aurelia-pal@1.3.0"
+      "aurelia-metadata": "npm:aurelia-metadata@1.0.4",
+      "aurelia-pal": "npm:aurelia-pal@1.8.0"
     },
     "npm:aurelia-loader@1.0.0": {
-      "aurelia-metadata": "npm:aurelia-metadata@1.0.3",
+      "aurelia-metadata": "npm:aurelia-metadata@1.0.4",
       "aurelia-path": "npm:aurelia-path@1.1.1"
     },
     "npm:aurelia-logging-console@1.0.0": {
-      "aurelia-logging": "npm:aurelia-logging@1.3.1"
+      "aurelia-logging": "npm:aurelia-logging@1.5.0"
     },
-    "npm:aurelia-metadata@1.0.3": {
-      "aurelia-pal": "npm:aurelia-pal@1.3.0"
+    "npm:aurelia-metadata@1.0.4": {
+      "aurelia-pal": "npm:aurelia-pal@1.8.0"
     },
     "npm:aurelia-pal-browser@1.2.1": {
-      "aurelia-pal": "npm:aurelia-pal@1.3.0"
+      "aurelia-pal": "npm:aurelia-pal@1.8.0"
     },
     "npm:aurelia-polyfills@1.2.1": {
-      "aurelia-pal": "npm:aurelia-pal@1.3.0"
+      "aurelia-pal": "npm:aurelia-pal@1.8.0"
     },
     "npm:aurelia-route-recognizer@1.1.0": {
       "aurelia-path": "npm:aurelia-path@1.1.1"
@@ -130,35 +136,35 @@ System.config({
       "aurelia-dependency-injection": "npm:aurelia-dependency-injection@1.3.1",
       "aurelia-event-aggregator": "npm:aurelia-event-aggregator@1.0.1",
       "aurelia-history": "npm:aurelia-history@1.0.0",
-      "aurelia-logging": "npm:aurelia-logging@1.3.1",
+      "aurelia-logging": "npm:aurelia-logging@1.5.0",
       "aurelia-path": "npm:aurelia-path@1.1.1",
       "aurelia-route-recognizer": "npm:aurelia-route-recognizer@1.1.0"
     },
-    "npm:aurelia-task-queue@1.2.0": {
-      "aurelia-pal": "npm:aurelia-pal@1.3.0"
+    "npm:aurelia-task-queue@1.3.1": {
+      "aurelia-pal": "npm:aurelia-pal@1.8.0"
     },
     "npm:aurelia-templating-binding@1.3.0": {
       "aurelia-binding": "npm:aurelia-binding@1.2.1",
-      "aurelia-logging": "npm:aurelia-logging@1.3.1",
+      "aurelia-logging": "npm:aurelia-logging@1.5.0",
       "aurelia-templating": "npm:aurelia-templating@1.4.1"
     },
     "npm:aurelia-templating-resources@1.4.0": {
       "aurelia-binding": "npm:aurelia-binding@1.2.1",
       "aurelia-dependency-injection": "npm:aurelia-dependency-injection@1.3.1",
       "aurelia-loader": "npm:aurelia-loader@1.0.0",
-      "aurelia-logging": "npm:aurelia-logging@1.3.1",
-      "aurelia-metadata": "npm:aurelia-metadata@1.0.3",
-      "aurelia-pal": "npm:aurelia-pal@1.3.0",
+      "aurelia-logging": "npm:aurelia-logging@1.5.0",
+      "aurelia-metadata": "npm:aurelia-metadata@1.0.4",
+      "aurelia-pal": "npm:aurelia-pal@1.8.0",
       "aurelia-path": "npm:aurelia-path@1.1.1",
-      "aurelia-task-queue": "npm:aurelia-task-queue@1.2.0",
+      "aurelia-task-queue": "npm:aurelia-task-queue@1.3.1",
       "aurelia-templating": "npm:aurelia-templating@1.4.1"
     },
     "npm:aurelia-templating-router@1.1.0": {
       "aurelia-binding": "npm:aurelia-binding@1.2.1",
       "aurelia-dependency-injection": "npm:aurelia-dependency-injection@1.3.1",
-      "aurelia-logging": "npm:aurelia-logging@1.3.1",
-      "aurelia-metadata": "npm:aurelia-metadata@1.0.3",
-      "aurelia-pal": "npm:aurelia-pal@1.3.0",
+      "aurelia-logging": "npm:aurelia-logging@1.5.0",
+      "aurelia-metadata": "npm:aurelia-metadata@1.0.4",
+      "aurelia-pal": "npm:aurelia-pal@1.8.0",
       "aurelia-path": "npm:aurelia-path@1.1.1",
       "aurelia-router": "npm:aurelia-router@1.3.0",
       "aurelia-templating": "npm:aurelia-templating@1.4.1"
@@ -167,18 +173,18 @@ System.config({
       "aurelia-binding": "npm:aurelia-binding@1.2.1",
       "aurelia-dependency-injection": "npm:aurelia-dependency-injection@1.3.1",
       "aurelia-loader": "npm:aurelia-loader@1.0.0",
-      "aurelia-logging": "npm:aurelia-logging@1.3.1",
-      "aurelia-metadata": "npm:aurelia-metadata@1.0.3",
-      "aurelia-pal": "npm:aurelia-pal@1.3.0",
+      "aurelia-logging": "npm:aurelia-logging@1.5.0",
+      "aurelia-metadata": "npm:aurelia-metadata@1.0.4",
+      "aurelia-pal": "npm:aurelia-pal@1.8.0",
       "aurelia-path": "npm:aurelia-path@1.1.1",
-      "aurelia-task-queue": "npm:aurelia-task-queue@1.2.0"
+      "aurelia-task-queue": "npm:aurelia-task-queue@1.3.1"
     },
     "npm:aurelia-testing@0.4.2": {
       "aurelia-bootstrapper": "npm:aurelia-bootstrapper@1.0.1",
       "aurelia-dependency-injection": "npm:aurelia-dependency-injection@1.3.1",
       "aurelia-framework": "npm:aurelia-framework@1.1.2",
-      "aurelia-logging": "npm:aurelia-logging@1.3.1",
-      "aurelia-pal": "npm:aurelia-pal@1.3.0",
+      "aurelia-logging": "npm:aurelia-logging@1.5.0",
+      "aurelia-pal": "npm:aurelia-pal@1.8.0",
       "aurelia-templating": "npm:aurelia-templating@1.4.1"
     },
     "npm:babel-runtime@5.8.38": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
       "lib": "dist/amd"
     },
     "dependencies": {
-      "aurelia-binding": "npm:aurelia-binding@^1.0.4",
+      "aurelia-binding": "npm:aurelia-binding@2.1.1",
       "aurelia-dependency-injection": "npm:aurelia-dependency-injection@^1.0.0",
       "aurelia-logging": "npm:aurelia-logging@^1.0.0",
       "aurelia-metadata": "npm:aurelia-metadata@^1.0.0",
@@ -61,7 +61,7 @@
     }
   },
   "dependencies": {
-    "aurelia-binding": "^1.0.4",
+    "aurelia-binding": "^2.1.1",
     "aurelia-dependency-injection": "^1.0.0",
     "aurelia-logging": "^1.0.0",
     "aurelia-metadata": "^1.0.0",
@@ -147,14 +147,14 @@
         "aurelia-kendoui-bridge/button/button",
         "aurelia-kendoui-bridge/buttongroup/buttongroup",
         "aurelia-kendoui-bridge/calendar/calendar",
-		"aurelia-kendoui-bridge/chat/chat",
+        "aurelia-kendoui-bridge/chat/chat",
         "aurelia-kendoui-bridge/colorpicker/colorpicker",
         "aurelia-kendoui-bridge/colorpalette/colorpalette",
         "aurelia-kendoui-bridge/combobox/combobox",
         "aurelia-kendoui-bridge/contextmenu/contextmenu",
         "aurelia-kendoui-bridge/dialog/dialog",
         "aurelia-kendoui-bridge/dropdownlist/dropdownlist",
-		"aurelia-kendoui-bridge/dropdowntree/dropdowntree",
+        "aurelia-kendoui-bridge/dropdowntree/dropdowntree",
         "aurelia-kendoui-bridge/datetimepicker/datetimepicker",
         "aurelia-kendoui-bridge/datepicker/datepicker",
         "aurelia-kendoui-bridge/draggable/draggable",
@@ -168,7 +168,7 @@
         "aurelia-kendoui-bridge/notification/notification",
         "aurelia-kendoui-bridge/notification/notification-template",
         "aurelia-kendoui-bridge/numerictextbox/numerictextbox",
-		"aurelia-kendoui-bridge/pager/pager",
+        "aurelia-kendoui-bridge/pager/pager",
         "aurelia-kendoui-bridge/panelbar/panelbar",
         "aurelia-kendoui-bridge/popup/popup",
         "aurelia-kendoui-bridge/progressbar/progressbar",

--- a/sample/config.js
+++ b/sample/config.js
@@ -28,18 +28,18 @@ System.config({
 
   map: {
     "aurelia-after-attached-plugin": "github:aurelia-ui-toolkits/aurelia-after-attached-plugin@0.1.3",
-    "aurelia-binding": "npm:aurelia-binding@1.2.1",
+    "aurelia-binding": "npm:aurelia-binding@2.1.1",
     "aurelia-bootstrapper": "npm:aurelia-bootstrapper@1.0.1",
     "aurelia-dependency-injection": "npm:aurelia-dependency-injection@1.3.1",
     "aurelia-event-aggregator": "npm:aurelia-event-aggregator@1.0.1",
     "aurelia-framework": "npm:aurelia-framework@1.1.2",
     "aurelia-http-client": "npm:aurelia-http-client@1.1.1",
     "aurelia-loader": "npm:aurelia-loader@1.0.0",
-    "aurelia-logging": "npm:aurelia-logging@1.3.1",
-    "aurelia-metadata": "npm:aurelia-metadata@1.0.3",
-    "aurelia-pal": "npm:aurelia-pal@1.3.0",
+    "aurelia-logging": "npm:aurelia-logging@1.5.0",
+    "aurelia-metadata": "npm:aurelia-metadata@1.0.4",
+    "aurelia-pal": "npm:aurelia-pal@1.8.0",
     "aurelia-router": "npm:aurelia-router@1.3.0",
-    "aurelia-task-queue": "npm:aurelia-task-queue@1.2.0",
+    "aurelia-task-queue": "npm:aurelia-task-queue@1.3.1",
     "aurelia-templating": "npm:aurelia-templating@1.4.1",
     "aurelia-templating-binding": "npm:aurelia-templating-binding@1.3.0",
     "aurelia-templating-resources": "npm:aurelia-templating-resources@1.4.0",
@@ -58,7 +58,7 @@ System.config({
     "showdown-prettify": "npm:showdown-prettify@1.3.0",
     "text": "github:systemjs/plugin-text@0.0.4",
     "github:aurelia-ui-toolkits/aurelia-after-attached-plugin@0.1.3": {
-      "aurelia-task-queue": "npm:aurelia-task-queue@1.2.0",
+      "aurelia-task-queue": "npm:aurelia-task-queue@1.3.1",
       "aurelia-templating": "npm:aurelia-templating@1.4.1"
     },
     "github:jspm/nodelibs-assert@0.1.0": {
@@ -98,10 +98,16 @@ System.config({
       "util": "npm:util@0.10.3"
     },
     "npm:aurelia-binding@1.2.1": {
-      "aurelia-logging": "npm:aurelia-logging@1.3.1",
-      "aurelia-metadata": "npm:aurelia-metadata@1.0.3",
-      "aurelia-pal": "npm:aurelia-pal@1.3.0",
-      "aurelia-task-queue": "npm:aurelia-task-queue@1.2.0"
+      "aurelia-logging": "npm:aurelia-logging@1.5.0",
+      "aurelia-metadata": "npm:aurelia-metadata@1.0.4",
+      "aurelia-pal": "npm:aurelia-pal@1.8.0",
+      "aurelia-task-queue": "npm:aurelia-task-queue@1.3.1"
+    },
+    "npm:aurelia-binding@2.1.1": {
+      "aurelia-logging": "npm:aurelia-logging@1.5.0",
+      "aurelia-metadata": "npm:aurelia-metadata@1.0.4",
+      "aurelia-pal": "npm:aurelia-pal@1.8.0",
+      "aurelia-task-queue": "npm:aurelia-task-queue@1.3.1"
     },
     "npm:aurelia-bootstrapper@1.0.1": {
       "aurelia-event-aggregator": "npm:aurelia-event-aggregator@1.0.1",
@@ -110,7 +116,7 @@ System.config({
       "aurelia-history-browser": "npm:aurelia-history-browser@1.0.0",
       "aurelia-loader-default": "npm:aurelia-loader-default@1.0.2",
       "aurelia-logging-console": "npm:aurelia-logging-console@1.0.0",
-      "aurelia-pal": "npm:aurelia-pal@1.3.0",
+      "aurelia-pal": "npm:aurelia-pal@1.8.0",
       "aurelia-pal-browser": "npm:aurelia-pal-browser@1.2.1",
       "aurelia-polyfills": "npm:aurelia-polyfills@1.2.1",
       "aurelia-router": "npm:aurelia-router@1.3.0",
@@ -120,51 +126,51 @@ System.config({
       "aurelia-templating-router": "npm:aurelia-templating-router@1.1.0"
     },
     "npm:aurelia-dependency-injection@1.3.1": {
-      "aurelia-metadata": "npm:aurelia-metadata@1.0.3",
-      "aurelia-pal": "npm:aurelia-pal@1.3.0"
+      "aurelia-metadata": "npm:aurelia-metadata@1.0.4",
+      "aurelia-pal": "npm:aurelia-pal@1.8.0"
     },
     "npm:aurelia-event-aggregator@1.0.1": {
-      "aurelia-logging": "npm:aurelia-logging@1.3.1"
+      "aurelia-logging": "npm:aurelia-logging@1.5.0"
     },
     "npm:aurelia-framework@1.1.2": {
       "aurelia-binding": "npm:aurelia-binding@1.2.1",
       "aurelia-dependency-injection": "npm:aurelia-dependency-injection@1.3.1",
       "aurelia-loader": "npm:aurelia-loader@1.0.0",
-      "aurelia-logging": "npm:aurelia-logging@1.3.1",
-      "aurelia-metadata": "npm:aurelia-metadata@1.0.3",
-      "aurelia-pal": "npm:aurelia-pal@1.3.0",
+      "aurelia-logging": "npm:aurelia-logging@1.5.0",
+      "aurelia-metadata": "npm:aurelia-metadata@1.0.4",
+      "aurelia-pal": "npm:aurelia-pal@1.8.0",
       "aurelia-path": "npm:aurelia-path@1.1.1",
-      "aurelia-task-queue": "npm:aurelia-task-queue@1.2.0",
+      "aurelia-task-queue": "npm:aurelia-task-queue@1.3.1",
       "aurelia-templating": "npm:aurelia-templating@1.4.1"
     },
     "npm:aurelia-history-browser@1.0.0": {
       "aurelia-history": "npm:aurelia-history@1.0.0",
-      "aurelia-pal": "npm:aurelia-pal@1.3.0"
+      "aurelia-pal": "npm:aurelia-pal@1.8.0"
     },
     "npm:aurelia-http-client@1.1.1": {
-      "aurelia-pal": "npm:aurelia-pal@1.3.0",
+      "aurelia-pal": "npm:aurelia-pal@1.8.0",
       "aurelia-path": "npm:aurelia-path@1.1.1"
     },
     "npm:aurelia-loader-default@1.0.2": {
       "aurelia-loader": "npm:aurelia-loader@1.0.0",
-      "aurelia-metadata": "npm:aurelia-metadata@1.0.3",
-      "aurelia-pal": "npm:aurelia-pal@1.3.0"
+      "aurelia-metadata": "npm:aurelia-metadata@1.0.4",
+      "aurelia-pal": "npm:aurelia-pal@1.8.0"
     },
     "npm:aurelia-loader@1.0.0": {
-      "aurelia-metadata": "npm:aurelia-metadata@1.0.3",
+      "aurelia-metadata": "npm:aurelia-metadata@1.0.4",
       "aurelia-path": "npm:aurelia-path@1.1.1"
     },
     "npm:aurelia-logging-console@1.0.0": {
-      "aurelia-logging": "npm:aurelia-logging@1.3.1"
+      "aurelia-logging": "npm:aurelia-logging@1.5.0"
     },
-    "npm:aurelia-metadata@1.0.3": {
-      "aurelia-pal": "npm:aurelia-pal@1.3.0"
+    "npm:aurelia-metadata@1.0.4": {
+      "aurelia-pal": "npm:aurelia-pal@1.8.0"
     },
     "npm:aurelia-pal-browser@1.2.1": {
-      "aurelia-pal": "npm:aurelia-pal@1.3.0"
+      "aurelia-pal": "npm:aurelia-pal@1.8.0"
     },
     "npm:aurelia-polyfills@1.2.1": {
-      "aurelia-pal": "npm:aurelia-pal@1.3.0"
+      "aurelia-pal": "npm:aurelia-pal@1.8.0"
     },
     "npm:aurelia-route-recognizer@1.1.0": {
       "aurelia-path": "npm:aurelia-path@1.1.1"
@@ -173,35 +179,35 @@ System.config({
       "aurelia-dependency-injection": "npm:aurelia-dependency-injection@1.3.1",
       "aurelia-event-aggregator": "npm:aurelia-event-aggregator@1.0.1",
       "aurelia-history": "npm:aurelia-history@1.0.0",
-      "aurelia-logging": "npm:aurelia-logging@1.3.1",
+      "aurelia-logging": "npm:aurelia-logging@1.5.0",
       "aurelia-path": "npm:aurelia-path@1.1.1",
       "aurelia-route-recognizer": "npm:aurelia-route-recognizer@1.1.0"
     },
-    "npm:aurelia-task-queue@1.2.0": {
-      "aurelia-pal": "npm:aurelia-pal@1.3.0"
+    "npm:aurelia-task-queue@1.3.1": {
+      "aurelia-pal": "npm:aurelia-pal@1.8.0"
     },
     "npm:aurelia-templating-binding@1.3.0": {
       "aurelia-binding": "npm:aurelia-binding@1.2.1",
-      "aurelia-logging": "npm:aurelia-logging@1.3.1",
+      "aurelia-logging": "npm:aurelia-logging@1.5.0",
       "aurelia-templating": "npm:aurelia-templating@1.4.1"
     },
     "npm:aurelia-templating-resources@1.4.0": {
       "aurelia-binding": "npm:aurelia-binding@1.2.1",
       "aurelia-dependency-injection": "npm:aurelia-dependency-injection@1.3.1",
       "aurelia-loader": "npm:aurelia-loader@1.0.0",
-      "aurelia-logging": "npm:aurelia-logging@1.3.1",
-      "aurelia-metadata": "npm:aurelia-metadata@1.0.3",
-      "aurelia-pal": "npm:aurelia-pal@1.3.0",
+      "aurelia-logging": "npm:aurelia-logging@1.5.0",
+      "aurelia-metadata": "npm:aurelia-metadata@1.0.4",
+      "aurelia-pal": "npm:aurelia-pal@1.8.0",
       "aurelia-path": "npm:aurelia-path@1.1.1",
-      "aurelia-task-queue": "npm:aurelia-task-queue@1.2.0",
+      "aurelia-task-queue": "npm:aurelia-task-queue@1.3.1",
       "aurelia-templating": "npm:aurelia-templating@1.4.1"
     },
     "npm:aurelia-templating-router@1.1.0": {
       "aurelia-binding": "npm:aurelia-binding@1.2.1",
       "aurelia-dependency-injection": "npm:aurelia-dependency-injection@1.3.1",
-      "aurelia-logging": "npm:aurelia-logging@1.3.1",
-      "aurelia-metadata": "npm:aurelia-metadata@1.0.3",
-      "aurelia-pal": "npm:aurelia-pal@1.3.0",
+      "aurelia-logging": "npm:aurelia-logging@1.5.0",
+      "aurelia-metadata": "npm:aurelia-metadata@1.0.4",
+      "aurelia-pal": "npm:aurelia-pal@1.8.0",
       "aurelia-path": "npm:aurelia-path@1.1.1",
       "aurelia-router": "npm:aurelia-router@1.3.0",
       "aurelia-templating": "npm:aurelia-templating@1.4.1"
@@ -210,11 +216,11 @@ System.config({
       "aurelia-binding": "npm:aurelia-binding@1.2.1",
       "aurelia-dependency-injection": "npm:aurelia-dependency-injection@1.3.1",
       "aurelia-loader": "npm:aurelia-loader@1.0.0",
-      "aurelia-logging": "npm:aurelia-logging@1.3.1",
-      "aurelia-metadata": "npm:aurelia-metadata@1.0.3",
-      "aurelia-pal": "npm:aurelia-pal@1.3.0",
+      "aurelia-logging": "npm:aurelia-logging@1.5.0",
+      "aurelia-metadata": "npm:aurelia-metadata@1.0.4",
+      "aurelia-pal": "npm:aurelia-pal@1.8.0",
       "aurelia-path": "npm:aurelia-path@1.1.1",
-      "aurelia-task-queue": "npm:aurelia-task-queue@1.2.0"
+      "aurelia-task-queue": "npm:aurelia-task-queue@1.3.1"
     },
     "npm:babel-runtime@5.8.38": {
       "process": "github:jspm/nodelibs-process@0.1.2"

--- a/sample/package.json
+++ b/sample/package.json
@@ -2,7 +2,7 @@
   "jspm": {
     "dependencies": {
       "aurelia-after-attached-plugin": "github:aurelia-ui-toolkits/aurelia-after-attached-plugin@^0.1.0",
-      "aurelia-binding": "npm:aurelia-binding@^1.0.0-beta.1.0.3",
+      "aurelia-binding": "npm:aurelia-binding@2.1.1",
       "aurelia-bootstrapper": "npm:aurelia-bootstrapper@^1.0.0-beta.1",
       "aurelia-dependency-injection": "npm:aurelia-dependency-injection@^1.0.0-beta.1",
       "aurelia-event-aggregator": "npm:aurelia-event-aggregator@^1.0.0-beta.1",
@@ -47,6 +47,7 @@
     "babel-eslint": "^4.1.1"
   },
   "dependencies": {
+    "aurelia-binding": "^2.1.1",
     "gulp": "^3.9.1"
   }
 }

--- a/src/common/template-gatherer.js
+++ b/src/common/template-gatherer.js
@@ -2,7 +2,7 @@ import {ControlProperties} from './control-properties';
 import {Util} from './util';
 import {inject} from 'aurelia-dependency-injection';
 import {KendoConfigBuilder} from '../config-builder';
-import {Lexer, ParserImplementation, createOverrideContext} from 'aurelia-binding';
+import {createOverrideContext, Parser} from 'aurelia-binding';
 
 @inject(ControlProperties, Util, KendoConfigBuilder)
 export class TemplateGatherer {
@@ -50,9 +50,9 @@ export class TemplateGatherer {
         // now we must parse the expression inside for="" on the ak-template
         // and set the template on the wrapper object
         // get a ParserImplementation for the expression inside for="editable.template"
-        let parser = new ParserImplementation(new Lexer(), c.for);
+        let parser = new Parser();
         // get the expression (generates a tree of AccessMembers)
-        let expression = parser.parseExpression();
+        let expression = parser.parse(c.for);
         // when the user uses "editable.template" it must be set as "kEditable.template"
         // so here we iterate through the tree until we get to the last object (the first part of the expression)
         let iterator = expression;


### PR DESCRIPTION
aurelia-binding 2.0.0 included [PR #679 ](https://github.com/aurelia/binding/pull/679) that significantly updated the Parsing subsystem.  In doing so, the submitter merged the Lexer() functions into the Parser() functions, so this library needs it's reference to Lexer in the `template-gatherer` VM to be addressed.  

This PR removes the Lexer() function and replaces it with a straight Parser() function.  In updating to aurelia-binding 2.0.0, you'll find this required many other packages to be also updated.  I've attempted to validate as much as possible that everything works in the Demo App and all built in tests have passed to this point.