### PR TITLE
Added caret to aurelia-binding version

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
       "lib": "dist/amd"
     },
     "dependencies": {
-      "aurelia-binding": "npm:aurelia-binding@2.1.1",
+      "aurelia-binding": "npm:aurelia-binding@^2.1.1",
       "aurelia-dependency-injection": "npm:aurelia-dependency-injection@^1.0.0",
       "aurelia-logging": "npm:aurelia-logging@^1.0.0",
       "aurelia-metadata": "npm:aurelia-metadata@^1.0.0",

--- a/sample/package.json
+++ b/sample/package.json
@@ -2,7 +2,7 @@
   "jspm": {
     "dependencies": {
       "aurelia-after-attached-plugin": "github:aurelia-ui-toolkits/aurelia-after-attached-plugin@^0.1.0",
-      "aurelia-binding": "npm:aurelia-binding@2.1.1",
+      "aurelia-binding": "npm:aurelia-binding@^2.1.1",
       "aurelia-bootstrapper": "npm:aurelia-bootstrapper@^1.0.0-beta.1",
       "aurelia-dependency-injection": "npm:aurelia-dependency-injection@^1.0.0-beta.1",
       "aurelia-event-aggregator": "npm:aurelia-event-aggregator@^1.0.0-beta.1",


### PR DESCRIPTION
Without this caret, if your project contains i.e. `aurelia-binding@2.5.0` then `jspm` installs two forks which breaks latest Aurelia based applications.